### PR TITLE
chore: simplify example repros. Use colorscheme preset for LazyVim

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ When enabling, do not forget to add the name of the colorscheme to the keywords!
 Or, alternatively:
 
 1. Add the name to property `keywords_to_always_enable`.
-2. When using custom presets: Add the name to the logic in the corresponding module.
+2. When using LazyVim: Use the `colorscheme` preset.
+3. When using custom presets: Create a `colorscheme` preset.
 
 _Note_: It is not possible to configure multiple fragments of the plugin.
 
@@ -99,14 +100,14 @@ _Note_: A preset setting that does not match a predefined preset will be ignored
     },
   },
 
-  -- Only use the coding module and telescope
-  -- plugins: 31 disabled
+  -- Only use telescope and the following modules: coding, colorscheme
+  -- plugins: 30 disabled
   {
     "abeldekat/lazyflex.nvim",
     import = "lazyflex.plugins.intercept",
     opts = {
-      lazyvim = { presets = { "coding" } },
-      keywords = { "tele", "plen", "tokyo" },
+      lazyvim = { presets = { "coding", "colorscheme" } },
+      keywords = { "tele", "plen" },
     },
   },
 
@@ -151,14 +152,14 @@ Add to **lazyflex**:
     },
   },
 
-  -- Using LazyVim's telescope spec
-  -- plugins: lazy.nvim, LazyVim, tokyonight, telescope, plenary
+  -- Using LazyVim's telescope spec and colorscheme module
+  -- plugins: lazy.nvim, LazyVim, tokyonight, catppuccin, telescope, plenary
   {
     "abeldekat/lazyflex.nvim",
     import = "lazyflex.plugins.intercept",
     opts = {
-      lazyvim = { config = { enabled = false } },
-      keywords = { "tele", "plen", "tokyo" },
+      lazyvim = { config = { enabled = false }, presets = {"colorscheme"} },
+      keywords = { "tele", "plen" },
     },
   },
 

--- a/lua/lazyflex/presets/lazyvim.lua
+++ b/lua/lazyflex/presets/lazyvim.lua
@@ -13,7 +13,7 @@ M.presets = {
     "mini.comment",
     "mini.ai",
   },
-  colorscheme = { "catppuccin" }, -- tokyonight should always be enabled
+  colorscheme = { "tokyonight", "catppuccin" },
   core = {}, -- dummy preset: core should always be enabled
   editor = {
     "neo-tree.nvim",
@@ -33,7 +33,7 @@ M.presets = {
     "neodev",
     "mason.nvim",
     "mason-lspconfig.nvim",
-    "cmp-nvim-lsp", --NOTE: see coding, has a cond property!
+    "cmp-nvim-lsp",
     "neodev",
     "none-ls",
     "null-ls",

--- a/repro/repro_lazy.lua
+++ b/repro/repro_lazy.lua
@@ -1,4 +1,8 @@
 -- Minimal `init.lua` to reproduce an issue. Save as `repro.lua` and run with `nvim -u repro.lua`
+--
+-- This example is for personal use only!
+-- Use lazyflex and the plugins provided to create different testing scenarios.
+-- As a minimal repro in an issue, lazyflex is superfluous.
 
 -- sets std paths to use .repro and bootstraps lazy
 -- DO NOT change the paths and don't remove the colorscheme
@@ -15,18 +19,16 @@ end
 local root = vim.fn.fnamemodify("./.repro", ":p")
 bootstrap(root)
 
--- optional: enable lazyflex.nvim
-local use_flex = false
-local plugin_flex = not use_flex and {}
-  or {
-    "abeldekat/lazyflex.nvim",
-    import = "lazyflex.plugins.intercept",
-    -- opts = { collection = false },
-  }
-
 -- install plugins
 local plugins = {
-  plugin_flex,
+  {
+    "abeldekat/lazyflex.nvim",
+    enabled = false,
+    import = "lazyflex.plugins.intercept",
+    opts = {
+      collection = false, -- use lazyflex without LazyVim
+    },
+  },
   "folke/tokyonight.nvim",
   -- add any other plugins here
 }

--- a/repro/repro_lazyvim.lua
+++ b/repro/repro_lazyvim.lua
@@ -14,18 +14,10 @@ end
 local root = vim.fn.fnamemodify("./.repro", ":p")
 bootstrap(root)
 
--- optional: enable lazyflex.nvim
-local use_flex = false
-local plugin_flex = not use_flex and {}
-  or {
-    "abeldekat/lazyflex.nvim",
-    import = "lazyflex.plugins.intercept",
-    -- opts = {},
-  }
-
 -- install plugins
 local plugins = {
-  plugin_flex,
+  -- optional: reduce the number of plugins needed to reproduce the problem
+  { "abeldekat/lazyflex.nvim", enabled = false, import = "lazyflex.plugins.intercept" },
   "folke/tokyonight.nvim",
   { "LazyVim/LazyVim", import = "lazyvim.plugins" },
   -- add any other plugins here


### PR DESCRIPTION
The example repros can be changed into simple specs, without the "or" construct. The `enabled` property is used, initially set to false.

For `LazyVim`, colorscheme `tokyonight` has been removed from `keywords_to_always_enable`, and added to the `colorscheme` preset.

